### PR TITLE
Reduced EBS volume size from 20 GB to 8 GB

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -61,7 +61,7 @@ custom:
   # The type of instance to launch into the ElasticSearch domain
   es_instanceType: "t2.small.elasticsearch"
   # The size in GB of the EBS volumes that contain the data
-  es_ebsVolumeGB: 20
+  es_ebsVolumeGB: 8
   # The number of read IOPS the DynamoDB table should support.
   ddb_readIOPS: 5
   # The number of write IOPS the DynamoDB table should support.


### PR DESCRIPTION
Hi @adrianhall, I really appreciate this example repo and the tutorials associated with it.  They are a great entry point for the subject.  I suggest that you reduce the EBS volume size to be within AWS Free Tier usage limits (10 GB-mo per month).  This is the only significant configuration change I've had to make while working through your tutorials.  Thanks!